### PR TITLE
Drop (optional?) dependency on symfony 3.0 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
     "require": {
         "php": ">=5.3.10",
         "robrichards/xmlseclibs": "~2.0",
-        "symfony/http-foundation": "~2.3|~3.0",
-        "symfony/event-dispatcher": "~2.3|~3.0"
+        "symfony/http-foundation": "~2.3",
+        "symfony/event-dispatcher": "~2.3"
     },
     "require-dev": {
         "symfony/dom-crawler": "~2.3",


### PR DESCRIPTION
These components require PHP 5.5.9 or greater.